### PR TITLE
Before murder callback compatibility with released 4.9

### DIFF
--- a/lib/unicorn/configurator.rb
+++ b/lib/unicorn/configurator.rb
@@ -41,6 +41,7 @@ class Unicorn::Configurator
     :before_exec => lambda { |server|
         server.logger.info("forked child re-executing...")
       },
+    :before_murder => nil,
     :pid => nil,
     :preload_app => false,
     :check_client_connection => false,
@@ -166,6 +167,14 @@ class Unicorn::Configurator
   # There is no corresponding after_exec hook (for obvious reasons).
   def before_exec(*args, &block)
     set_hook(:before_exec, block_given? ? block : args[0], 1)
+  end
+
+  # Sets the before_murder hook to a gien Proc object. This Proc object
+  # will be called by the master process before killing a lazy worker
+  # with SIGKILL, the point of this callback is NOT to prevent killing
+  # but to provide an instrumentation hook
+  def before_murder(*args, &block)
+    set_hook(:before_murder, block_given? ? block : args[0], 1)
   end
 
   # sets the timeout of worker processes to +seconds+.  Workers

--- a/lib/unicorn/configurator.rb
+++ b/lib/unicorn/configurator.rb
@@ -169,12 +169,27 @@ class Unicorn::Configurator
     set_hook(:before_exec, block_given? ? block : args[0], 1)
   end
 
-  # Sets the before_murder hook to a gien Proc object. This Proc object
+  # Sets the before_murder hook to a given Proc object. This Proc object
   # will be called by the master process before killing a lazy worker
   # with SIGKILL, the point of this callback is NOT to prevent killing
   # but to provide an instrumentation hook
   def before_murder(*args, &block)
-    set_hook(:before_murder, block_given? ? block : args[0], 1)
+    set_hook_arg = if block_given?
+      # This hook is meant a an instrumentation point, it should not prevent the
+      # worker from getting killed exception will be logged and move on
+      new_block = Proc.new do |server, worker, wpid|
+        begin
+          block.call(server, worker, wpid)
+        rescue StandardError => e
+          server.logger.error("Error executing before murder for PID: #{wpid} error: #{e.inspect}")
+          server.logger.error(e.backtrace.join("\n"))
+        end
+      end
+    else
+      args[0]
+    end
+
+    set_hook(:before_murder, set_hook_arg, 3)
   end
 
   # sets the timeout of worker processes to +seconds+.  Workers

--- a/lib/unicorn/http_server.rb
+++ b/lib/unicorn/http_server.rb
@@ -475,7 +475,7 @@ class Unicorn::HttpServer
       next_sleep = 0
       logger.error "worker=#{worker.nr} PID:#{wpid} timeout " \
                    "(#{diff}s > #{@timeout}s), killing"
-      before_murder.call(wpid) if before_murder
+      before_murder.call(self, worker, wpid) if before_murder
       kill_worker(:KILL, wpid) # take no prisoners for timeout violations
     end
     next_sleep <= 0 ? 1 : next_sleep

--- a/lib/unicorn/http_server.rb
+++ b/lib/unicorn/http_server.rb
@@ -15,7 +15,8 @@ class Unicorn::HttpServer
                 :before_fork, :after_fork, :before_exec,
                 :listener_opts, :preload_app,
                 :reexec_pid, :orig_app, :init_listeners,
-                :master_pid, :config, :ready_pipe, :user
+                :master_pid, :config, :ready_pipe, :user,
+                :before_murder
 
   attr_reader :pid, :logger
   include Unicorn::SocketHelper
@@ -474,6 +475,7 @@ class Unicorn::HttpServer
       next_sleep = 0
       logger.error "worker=#{worker.nr} PID:#{wpid} timeout " \
                    "(#{diff}s > #{@timeout}s), killing"
+      before_murder.call(wpid) if before_murder
       kill_worker(:KILL, wpid) # take no prisoners for timeout violations
     end
     next_sleep <= 0 ? 1 : next_sleep

--- a/unicorn.gemspec
+++ b/unicorn.gemspec
@@ -14,7 +14,7 @@ end.compact
 
 Gem::Specification.new do |s|
   s.name = %q{unicorn-camilo}
-  s.version = "4.8.2.5.16"
+  s.version = "4.8.2.5.19"
   s.authors = ["#{name} hackers"]
   s.summary = summary
   s.description = readme_description

--- a/unicorn.gemspec
+++ b/unicorn.gemspec
@@ -13,8 +13,8 @@ test_files = manifest.grep(%r{\Atest/unit/test_.*\.rb\z}).map do |f|
 end.compact
 
 Gem::Specification.new do |s|
-  s.name = %q{unicorn}
-  s.version = ENV["VERSION"].dup
+  s.name = %q{unicorn-camilo}
+  s.version = "4.8.2.5.16"
   s.authors = ["#{name} hackers"]
   s.summary = summary
   s.description = readme_description

--- a/unicorn.gemspec
+++ b/unicorn.gemspec
@@ -14,7 +14,7 @@ end.compact
 
 Gem::Specification.new do |s|
   s.name = %q{unicorn-camilo}
-  s.version = "4.8.2.5.19"
+  s.version = "4.9"
   s.authors = ["#{name} hackers"]
   s.summary = summary
   s.description = readme_description


### PR DESCRIPTION
Turns out v5 is still WIP. As per http://unicorn.bogomips.org/NEWS.html , what went into unicorn-camilo 5 needs to be stripped from commit https://github.com/Shopify/unicorn/commit/ea730f93b20ef582128f7c664f7b57953f855a09 in order to be 100% inline with the last released 4.9 (before_murder aside)

This also builds unicorn-camilo v4.9
