### PR TITLE
ensure before murder is called only once

### DIFF
--- a/lib/unicorn/http_server.rb
+++ b/lib/unicorn/http_server.rb
@@ -1,4 +1,5 @@
 # -*- encoding: binary -*-
+require 'set'
 
 # This is the process manager of Unicorn. This manages worker
 # processes which in turn handle the I/O and application process.
@@ -91,6 +92,7 @@ class Unicorn::HttpServer
     @self_pipe = []
     @workers = {} # hash maps PIDs to Workers
     @sig_queue = [] # signal queue used for self-piping
+    @before_murder_called = Set.new() # ensures before_murder is called only once
 
     # we try inheriting listeners first, so we bind them later.
     # we don't write the pid file until we've bound listeners in case
@@ -394,6 +396,7 @@ class Unicorn::HttpServer
         self.pid = pid.chomp('.oldbin') if pid
         proc_name 'master'
       else
+        @before_murder_called.delete(wpid)
         worker = @workers.delete(wpid) and worker.close rescue nil
         m = "reaped #{status.inspect} worker=#{worker.nr rescue 'unknown'}"
         status.success? ? logger.info(m) : logger.error(m)
@@ -475,7 +478,10 @@ class Unicorn::HttpServer
       next_sleep = 0
       logger.error "worker=#{worker.nr} PID:#{wpid} timeout " \
                    "(#{diff}s > #{@timeout}s), killing"
-      before_murder.call(self, worker, wpid) if before_murder
+      if before_murder and not @before_murder_called.include?(wpid)
+        before_murder.call(self, worker, wpid)
+        @before_murder_called.add(wpid) # This ensures we call before_murder only once
+      end
       kill_worker(:KILL, wpid) # take no prisoners for timeout violations
     end
     next_sleep <= 0 ? 1 : next_sleep
@@ -683,6 +689,7 @@ class Unicorn::HttpServer
   def kill_worker(signal, wpid)
     Process.kill(signal, wpid)
   rescue Errno::ESRCH
+    @before_murder_called.delete(wpid)
     worker = @workers.delete(wpid) and worker.close rescue nil
   end
 

--- a/lib/unicorn/http_server.rb
+++ b/lib/unicorn/http_server.rb
@@ -478,7 +478,7 @@ class Unicorn::HttpServer
       next_sleep = 0
       logger.error "worker=#{worker.nr} PID:#{wpid} timeout " \
                    "(#{diff}s > #{@timeout}s), killing"
-      if before_murder and not @before_murder_called.include?(wpid)
+      if before_murder && !@before_murder_called.include?(wpid)
         before_murder.call(self, worker, wpid)
         @before_murder_called.add(wpid) # This ensures we call before_murder only once
       end

--- a/lib/unicorn/http_server.rb
+++ b/lib/unicorn/http_server.rb
@@ -92,7 +92,7 @@ class Unicorn::HttpServer
     @self_pipe = []
     @workers = {} # hash maps PIDs to Workers
     @sig_queue = [] # signal queue used for self-piping
-    @before_murder_called = Set.new() # ensures before_murder is called only once
+    @before_murder_called = Set.new # ensures before_murder is called only once
 
     # we try inheriting listeners first, so we bind them later.
     # we don't write the pid file until we've bound listeners in case
@@ -478,10 +478,8 @@ class Unicorn::HttpServer
       next_sleep = 0
       logger.error "worker=#{worker.nr} PID:#{wpid} timeout " \
                    "(#{diff}s > #{@timeout}s), killing"
-      if before_murder && !@before_murder_called.include?(wpid)
-        before_murder.call(self, worker, wpid)
-        @before_murder_called.add(wpid) # This ensures we call before_murder only once
-      end
+      # Ensure we call before_murder only once
+      before_murder.call(self, worker, wpid) if before_murder and @before_murder_called.add?(wpid)
       kill_worker(:KILL, wpid) # take no prisoners for timeout violations
     end
     next_sleep <= 0 ? 1 : next_sleep

--- a/t/before_murder.ru
+++ b/t/before_murder.ru
@@ -1,0 +1,7 @@
+use Rack::ContentLength
+use Rack::ContentType, "text/plain"
+app = lambda do |env|
+  Process.kill(:STOP, Process.pid)
+  [ 200, {}, [ "#$$\n" ] ]
+end
+run app

--- a/t/before_murder_once.ru
+++ b/t/before_murder_once.ru
@@ -1,0 +1,7 @@
+use Rack::ContentLength
+use Rack::ContentType, "text/plain"
+app = lambda do |env|
+  Process.kill(:STOP, Process.pid)
+  [ 200, {}, [ "#$$\n" ] ]
+end
+run app

--- a/t/before_murder_once.ru
+++ b/t/before_murder_once.ru
@@ -1,7 +1,0 @@
-use Rack::ContentLength
-use Rack::ContentType, "text/plain"
-app = lambda do |env|
-  Process.kill(:STOP, Process.pid)
-  [ 200, {}, [ "#$$\n" ] ]
-end
-run app

--- a/t/t0023-before-murder.sh
+++ b/t/t0023-before-murder.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+. ./test-lib.sh
+t_plan 5 "before murder is called"
+
+t_begin "setup and start" && {
+	unicorn_setup
+	cat >> $unicorn_config <<EOF
+timeout 5
+after_fork { |s,w| File.open('$fifo','w') { |f| f.write '.' } }
+before_murder do |s, w, p| 
+  \$stderr.puts "before murder called:"
+end
+EOF
+	unicorn -c $unicorn_config before_murder.ru &
+	test '.' = $(cat $fifo)
+	unicorn_wait_start
+}
+
+t_begin "start worker=0" && {
+	pid=$(curl http://$listen/) || true
+}
+
+t_begin "ensure before murder log is present" && {
+	dbgcat r_err
+	grep 'before murder called:' $r_err 
+	dbgcat r_err
+	> $r_err
+}
+
+t_begin "killing succeeds" && {
+  kill $unicorn_pid
+  wait
+  kill -0 $unicorn_pid && false
+}
+
+t_begin "check stderr" && {
+	check_stderr
+}
+
+t_done

--- a/t/t0024-before-murder_once.sh
+++ b/t/t0024-before-murder_once.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+. ./test-lib.sh
+t_plan 5 "before murder is called"
+
+t_begin "setup and start" && {
+	unicorn_setup
+	cat >> $unicorn_config <<EOF
+timeout 5
+after_fork { |s,w| File.open('$fifo','w') { |f| f.write '.' } }
+class Unicorn::HttpServer
+  def kill_worker(signal, wpid)
+    @iteration ||= 0
+    \$stderr.puts "kill_worker #{signal} #{wpid} #{@iteration}"
+    if @iteration > 0 then
+      Process.kill(signal, wpid)
+    end
+    @iteration = @iteration + 1
+  rescue Errno::ESRCH
+    @before_murder_called.delete(wpid)
+    worker = @workers.delete(wpid) and worker.close rescue nil
+  end
+end
+before_murder do |s, w, p| 
+  \$stderr.puts "before murder called:"
+end
+EOF
+	unicorn -c $unicorn_config before_murder.ru &
+	test '.' = $(cat $fifo)
+	unicorn_wait_start
+}
+
+t_begin "start worker=0" && {
+	pid=$(curl http://$listen/) || true
+}
+
+t_begin "ensure before murder log is present once and killing is present twice" && {
+	dbgcat r_err
+	grep 'before murder called:' $r_err 
+  test 1 -eq $(grep "before murder called:" $r_err | count_lines)
+  test 2 -eq $(grep timeout $r_err | grep killing | count_lines)
+  test 2 -eq $(grep "kill_worker KILL" $r_err | count_lines)
+	dbgcat r_err
+	> $r_err
+}
+
+t_begin "killing succeeds" && {
+  kill $unicorn_pid
+  wait
+  kill -0 $unicorn_pid && false
+}
+
+t_begin "check stderr" && {
+	check_stderr
+}
+
+t_done

--- a/t/t0024-before-murder_once.sh
+++ b/t/t0024-before-murder_once.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 . ./test-lib.sh
-t_plan 5 "before murder is called"
+t_plan 5 "before murder is called only once"
 
 t_begin "setup and start" && {
 	unicorn_setup

--- a/unicorn.gemspec
+++ b/unicorn.gemspec
@@ -1,4 +1,5 @@
 # -*- encoding: binary -*-
+ENV["VERSION"] or abort "VERSION= must be specified"
 manifest = File.readlines('.manifest').map! { |x| x.chomp! }
 require 'olddoc'
 extend Olddoc::Gemspec

--- a/unicorn.gemspec
+++ b/unicorn.gemspec
@@ -13,7 +13,7 @@ test_files = manifest.grep(%r{\Atest/unit/test_.*\.rb\z}).map do |f|
 end.compact
 
 Gem::Specification.new do |s|
-  s.name = %q{unicorn-camilo}
+  s.name = %q{unicorn-shopify}
   s.version = "4.8.2.5.23"
   s.authors = ["#{name} hackers"]
   s.summary = summary

--- a/unicorn.gemspec
+++ b/unicorn.gemspec
@@ -1,5 +1,4 @@
 # -*- encoding: binary -*-
-ENV["VERSION"] or abort "VERSION= must be specified"
 manifest = File.readlines('.manifest').map! { |x| x.chomp! }
 require 'olddoc'
 extend Olddoc::Gemspec

--- a/unicorn.gemspec
+++ b/unicorn.gemspec
@@ -14,7 +14,7 @@ end.compact
 
 Gem::Specification.new do |s|
   s.name = %q{unicorn-camilo}
-  s.version = "4.8.2.5.19"
+  s.version = "4.8.2.5.23"
   s.authors = ["#{name} hackers"]
   s.summary = summary
   s.description = readme_description


### PR DESCRIPTION
it turns out that it is possible for unicorn to call before_murder more than once for the same worker that it is trying to kill. This specifically happens when it loops around finding things to kill, and decides it needs to kill a worker. It sends it a SIGKILL, and then continues around its loop. Eventually it finishes this loop and return to its main loop from where it could be woken up immediately. It tries to reap_workers which calls waitpid2 with a NOHANG flag. Since a waitpid status is available only _after_ a process is completely terminated, it is very likely that the process is still around, and we would call before_murder again. 

This change ensure that does not happen. It primarily prevents the before_murder from being called multiple times, but I could also wrap the entire `before_murder .. kill_worker` so we don't log, call before_murder or call kill_worker multiple times.

There are many cases we are sending a kill to the same process more than once, and as a result we also call before_murder as many times.

@camilo 
